### PR TITLE
handling xmpp errors 

### DIFF
--- a/src/com/juick/xmpp/Iq.java
+++ b/src/com/juick/xmpp/Iq.java
@@ -57,6 +57,16 @@ public class Iq extends Stanza {
         reply.type = Type.result;
         return reply;
     }
+    
+    public Iq error() {
+        // TODO: implement other types
+        Iq error = new Iq();
+        error.from = to;
+        error.to = from;
+        error.id = this.id;
+        error.type = Type.error;        
+        return error;
+    }
 
     public static Iq parse(XmlPullParser parser) throws XmlPullParserException, java.io.IOException {
         Iq iq = new Iq();
@@ -83,6 +93,9 @@ public class Iq extends Stanza {
         String str = "<" + TagName + super.toString() + ">";
         for (Enumeration e = childs.elements(); e.hasMoreElements();) {
             str += e.nextElement().toString();
+        }
+        if (type.equals(Type.error)) {
+            str += "<error type='cancel'><service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas' /></error>";
         }
         str += "</" + TagName + ">";
         return str;

--- a/src/com/juick/xmpp/IqListener.java
+++ b/src/com/juick/xmpp/IqListener.java
@@ -21,7 +21,8 @@ package com.juick.xmpp;
  *
  * @author Ugnich Anton
  */
-public interface IqListener {
+public interface IqListener {    
+    
 
-    public void onIq(final Iq iq);
+    public boolean onIq(final Iq iq);
 }

--- a/src/com/juick/xmpp/XmppConnection.java
+++ b/src/com/juick/xmpp/XmppConnection.java
@@ -174,16 +174,20 @@ public abstract class XmppConnection extends Thread {
             } else if (tag.equals("iq")) {
                 Iq iq = Iq.parse(parser);
                 final String key = iq.from.toString() + "\n" + iq.id;
+                boolean parsed = false;
                 if (listenersIqId.containsKey(key)) {
                     IqListener l = (IqListener) listenersIqId.get(key);
-                    l.onIq(iq);
+                    parsed |= l.onIq(iq);
                     listenersIqId.remove(key);
                 } else {
                     for (Enumeration e = listenersIq.elements(); e.hasMoreElements();) {
                         IqListener l = (IqListener) e.nextElement();
-                        l.onIq(iq);
+                        parsed |= l.onIq(iq);
                     }
                 }
+                if (!parsed) {
+                    send(iq.error());
+                }                    
             } else {
                 XmlUtils.skip(parser);
             }

--- a/src/com/juick/xmpp/XmppConnectionClient.java
+++ b/src/com/juick/xmpp/XmppConnectionClient.java
@@ -90,7 +90,7 @@ public class XmppConnectionClient extends XmppConnection implements IqListener {
     }
 
     @Override
-    public void onIq(Iq iq) {
+    public boolean onIq(Iq iq) {
         if (!iq.childs.isEmpty() && ((ChildElement) iq.childs.firstElement()).getXMLNS().equals(ResourceBinding.XMLNS)) {
             ResourceBinding rb = (ResourceBinding) iq.childs.firstElement();
             if (rb.jid != null) {
@@ -100,7 +100,9 @@ public class XmppConnectionClient extends XmppConnection implements IqListener {
                 XmppListener xl = (XmppListener) e.nextElement();
                 xl.onAuth(jid.Resource);
             }
+            return true;
         }
+        return false;
     }
 }
 


### PR DESCRIPTION
rfc6920, 8.2.3.  IQ Semantics
....
3.An entity that receives an IQ request of type "get" or "set" MUST reply with an IQ response of type "result" or "error". The response MUST preserve the 'id' attribute of the request (or be empty if the generated stanza did not include an 'id' attribute). 
....
